### PR TITLE
Updated <template> matching regex

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,7 +4,7 @@ import * as vscode from 'vscode';
 import { Decorator } from './decorater';
 
 const scriptRegex = /<script.*?>[\s\S]*?<\/script>/g;
-const htmlRegex = /<template.*?>[\s\S]*?<\/template>/g;
+const htmlRegex = /<template\b[^>]*>[\s\S]*<\/template>/g;
 const styleRegex = /<style.*?>[\s\S]*?<\/style>/g;
 
 let scriptDecorator = new Decorator('script', scriptRegex);


### PR DESCRIPTION
Updated <template> matching regex with a greedier version so all nested `<template>` elements are included in the first match.

Old vs new comparison:
Old (broken): [https://regex101.com/r/vcdAPv/1](https://regex101.com/r/vcdAPv/1)
New (fixed): [https://regex101.com/r/OG6Ep2/1](https://regex101.com/r/OG6Ep2/1)


fixes #3 